### PR TITLE
remove unnecessary runtime dependencies

### DIFF
--- a/gemrat.gemspec
+++ b/gemrat.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "colored", "1.2"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_runtime_dependency "rspec", "2.13.0"
-  spec.add_runtime_dependency "pry", "0.9.12.2"
-  spec.add_runtime_dependency "colored", "1.2"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
As mentioned in #1, there's no reason to keep these gems as runtime dependencies. 
