### PR TITLE
Ignore commented gem entries in Gemfile

### DIFF
--- a/lib/gemrat/gemfile.rb
+++ b/lib/gemrat/gemfile.rb
@@ -42,7 +42,7 @@ module Gemrat
       end
 
       def check(gem, file)
-        @grep_file = file.grep(/gem.*#{gem.name}.*/)
+        @grep_file = file.grep(/^[^\#]*gem.*#{gem.name}.*/)
         @current_gem_version = get_current_gem_version
         raise DuplicateGemFound if duplicate_gem? gem
 


### PR DESCRIPTION
As the title says, gemrat was incorrectly skipping gems that were commented out in the Gemfile. e.g.:

  #  gem 'unicorn'

This little change to the regex should avoid this mistake.
